### PR TITLE
Add pinned note bug fix

### DIFF
--- a/src/js/views/omnibox.js
+++ b/src/js/views/omnibox.js
@@ -91,8 +91,12 @@
         * @private
         */
         _onSavePinClicked: function(event) {
-            this.editor.setText('! ' + this.editor.getText());
-            this.save();
+          var contents = L.util.strip(this.editor.getText());
+          if (contents[0] != '!') {
+            contents = '! ' + contents;
+          }
+          this.editor.setText(contents);
+          this.save();
         },
         save: function() {
             this.assertRendered();


### PR DESCRIPTION
Fixed problem where notes beginning with !! doubled !!s when "keep this note at the top of my list" was clicked.
