### PR TITLE
Clickable tags

### DIFF
--- a/src/css/notes.css
+++ b/src/css/notes.css
@@ -107,3 +107,7 @@
     display: none;
 }
 
+.listit_tag:hover {
+  cursor: pointer;
+}
+

--- a/src/js/views/notes.js
+++ b/src/js/views/notes.js
@@ -69,22 +69,27 @@
       this.$el.children('.contents').html(this.model.get('contents'));
     },
     events: {
-      'click     .close-btn':   'onRemoveClicked',
-      'click     .contents':    'onClick',
-      'click     .contents a':  'onLinkOpen',
-      'keyup     .contents':    'onKeyUp',
-      'blur      .editor':      'onBlur',
-      'keydown   .editor':      'onKeyDown',
-      'click     .pin-icon':    'onPinToggle',
-      'mousedown .pin-icon':    function(event){event.preventDefault();},
-      'click     .save-icon':   'onSaveToggle',
-      'mousedown .save-icon':   function(event){event.preventDefault();}
+      'click     .close-btn':             'onRemoveClicked',
+      'click     .contents':              'onClick',
+      'click     .contents a':            'onLinkOpen',
+      'click     .contents .listit_tag':  'onTagClick',
+      'keyup     .contents':              'onKeyUp',
+      'blur      .editor':                'onBlur',
+      'keydown   .editor':                'onKeyDown',
+      'click     .pin-icon':              'onPinToggle',
+      'mousedown .pin-icon':              function(event){event.preventDefault();},
+      'click     .save-icon':             'onSaveToggle',
+      'mousedown .save-icon':             function(event){event.preventDefault();}
     },
     onLinkOpen: function(event) {
       this.model.trigger('user:open-bookmark', this.model, this, event.target.href);
     },
     onRemoveClicked: function() {
       L.notebook.trashNote(this.model);
+      return false;
+    },
+    onTagClick: function(event) {
+      L.omnibox.set('text', event.target.textContent);
       return false;
     },
     expand: function() {


### PR DESCRIPTION
Clicking on tags now filters notes by clicked tag. (currently, tag replaces text in omnibox - this should be changed when split-box search is merged)
